### PR TITLE
FE: [feature] 대시보드 상세보기 페이지 구축

### DIFF
--- a/src/frontend/eyesee-admin/src/app/dashboard/[examId]/[userId]/page.tsx
+++ b/src/frontend/eyesee-admin/src/app/dashboard/[examId]/[userId]/page.tsx
@@ -11,9 +11,9 @@ const UserDetailPage = () => {
   const [vidieoNum, setVideoNum] = useState(0);
 
   return (
-    <div className="flex w-screen h-screen">
-      <TimeLine timeLineData={userDetailData} />
-      <div className="grow bg-[#0E1D3C] text-white p-10">
+    <div className="flex w-screen h-screen bg-[#0E1D3C]">
+      <TimeLine timeLineData={userDetailData} setVideoNum={setVideoNum} />
+      <div className="grow text-white p-10">
         <TestInfo examName="융합캡스톤디자인 중간시험" examDuration={120} />
         <div>
           <CheatingVideo
@@ -27,12 +27,12 @@ const UserDetailPage = () => {
           />
           <div className="flex gap-5 py-5">
             {userDetailData.cheatingVideos.map((video, index) => (
-              <div key={index} className="h-28 rounded-sm overflow-hidden">
-                <img
-                  className="object-contain w-full h-full"
-                  src="https://images.pexels.com/photos/3808060/pexels-photo-3808060.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
-                  alt="image"
-                />
+              <div
+                key={index}
+                onClick={() => setVideoNum(index)}
+                className="h-28 max-w-48 rounded-sm overflow-hidden"
+              >
+                <video src={video.filepath} />
               </div>
             ))}
           </div>

--- a/src/frontend/eyesee-admin/src/app/dashboard/[examId]/[userId]/page.tsx
+++ b/src/frontend/eyesee-admin/src/app/dashboard/[examId]/[userId]/page.tsx
@@ -1,7 +1,45 @@
-import React from "react";
+"use client";
+
+import TestInfo from "@/components/dashBoard/TestInfo";
+import CheatingVideo from "@/components/userDetail/CheatingVideo";
+import TimeLine from "@/components/userDetail/TimeLine";
+import { dummyTimeLineData } from "@/types/timeLine";
+import React, { useState } from "react";
 
 const UserDetailPage = () => {
-  return <div>UserDetailPage</div>;
+  const userDetailData = dummyTimeLineData;
+  const [vidieoNum, setVideoNum] = useState(0);
+
+  return (
+    <div className="flex w-screen h-screen">
+      <TimeLine timeLineData={userDetailData} />
+      <div className="grow bg-[#0E1D3C] text-white p-10">
+        <TestInfo examName="융합캡스톤디자인 중간시험" examDuration={120} />
+        <div>
+          <CheatingVideo
+            cheatingVideo={userDetailData.cheatingVideos[vidieoNum]}
+            cheatingType={
+              userDetailData.cheatingStatistics[vidieoNum].cheatingType
+            }
+            cheatingCounts={
+              userDetailData.cheatingStatistics[vidieoNum].cheatingCount
+            }
+          />
+          <div className="flex gap-5 py-5">
+            {userDetailData.cheatingVideos.map((video, index) => (
+              <div key={index} className="h-28 rounded-sm overflow-hidden">
+                <img
+                  className="object-contain w-full h-full"
+                  src="https://images.pexels.com/photos/3808060/pexels-photo-3808060.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
+                  alt="image"
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default UserDetailPage;

--- a/src/frontend/eyesee-admin/src/app/dashboard/[examId]/page.tsx
+++ b/src/frontend/eyesee-admin/src/app/dashboard/[examId]/page.tsx
@@ -7,7 +7,7 @@ const DashBoardPage = () => {
   const sessionData = testSesstionData;
 
   return (
-    <div className="flex h-screen w-screen bg-[##0E1D3C]">
+    <div className="flex min-h-screen w-screen bg-[##0E1D3C]">
       <UserSection sessionData={sessionData} />
       <DashBoardSection sesstionData={sessionData} />
     </div>

--- a/src/frontend/eyesee-admin/src/app/mypage/page.tsx
+++ b/src/frontend/eyesee-admin/src/app/mypage/page.tsx
@@ -7,7 +7,7 @@ import React from "react";
 
 const MyPage = () => {
   return (
-    <div className="w-screen h-screen flex flex-col items-center">
+    <div className="w-screen min-h-screen flex flex-col items-center">
       <Navbar bgColr="bg-[#0E1D3C]" />
       <div className="w-[1100px] flex flex-col justify-center pt-20 pb-14">
         <Header title="나의 시험 조회" />

--- a/src/frontend/eyesee-admin/src/assets/icons/Circle.svg
+++ b/src/frontend/eyesee-admin/src/assets/icons/Circle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <circle cx="8" cy="8" r="8" fill="black"/>
+</svg>

--- a/src/frontend/eyesee-admin/src/components/common/Navbar.tsx
+++ b/src/frontend/eyesee-admin/src/components/common/Navbar.tsx
@@ -17,10 +17,10 @@ const Navbar = ({ bgColr }: NavbarProps) => {
 
   return (
     <div
-      className={`${bgColr} flex w-screen h-32 items-center justify-between px-12`}
+      className={`${bgColr} flex w-screen h-[12vh] items-center justify-between px-12`}
     >
       <div>
-        <Logo />
+        <Logo onClick={() => handleNavigation("/")} />
       </div>
       <div className="flex justify-between gap-16">
         <button className="text-2xl text-white">About us</button>

--- a/src/frontend/eyesee-admin/src/components/dashBoard/DashBoardCard.tsx
+++ b/src/frontend/eyesee-admin/src/components/dashBoard/DashBoardCard.tsx
@@ -6,11 +6,16 @@ import { useParams, useRouter } from "next/navigation";
 
 type DashBoardCardProps = {
   user: user;
+  exam: {
+    name: string;
+    duration: number;
+  };
 };
 
-const DashBoardCard = ({ user }: DashBoardCardProps) => {
+const DashBoardCard = ({ user, exam }: DashBoardCardProps) => {
   const router = useRouter();
   const { examId } = useParams();
+
   const handleClick = () => {
     router.push(`/dashboard/${examId}/${user.userId}`);
   };

--- a/src/frontend/eyesee-admin/src/components/dashBoard/DashBoardSection.tsx
+++ b/src/frontend/eyesee-admin/src/components/dashBoard/DashBoardSection.tsx
@@ -8,6 +8,7 @@ import DashBoardCard from "./DashBoardCard";
 import { useState } from "react";
 import TableSetModal from "./TableSetModal";
 import TestCodeModal from "./TestCodeModal";
+import TestInfo from "./TestInfo";
 
 type DashBoardSectionProps = {
   sesstionData: testSesstion;
@@ -38,17 +39,14 @@ const DashBoardSection = ({ sesstionData }: DashBoardSectionProps) => {
         <TestCodeModal setCodeModalOpen={setCodeModalOpen} code={"12345"} />
       )}
       <div className="grow bg-[#0E1D3C] text-white p-10">
-        <div>
-          <p className="text-[20px] font-bold">{sesstionData.examName}</p>
-          <p className="text-[18px] font-bold">
-            🕐 {sesstionData.examDuration}
-          </p>
-        </div>
-        <div className="w-full flex justify-end items-center gap-5 mb-5">
+        <TestInfo
+          examDuration={sesstionData.examDuration}
+          examName={sesstionData.examName}
+        >
           <GridIcon onClick={() => setTableModalOpen(true)} />
           <PeopleIcon onClick={() => setCodeModalOpen(true)} />
           <RowMoreIcon />
-        </div>
+        </TestInfo>
         <div
           className="grid gap-5 justify-center items-center"
           style={{
@@ -57,7 +55,14 @@ const DashBoardSection = ({ sesstionData }: DashBoardSectionProps) => {
         >
           {sesstionData.user.map((user) => (
             <div key={user.userId} className="flex justify-center">
-              <DashBoardCard key={user.userId} user={user} />
+              <DashBoardCard
+                key={user.userId}
+                user={user}
+                exam={{
+                  name: sesstionData.examName,
+                  duration: sesstionData.examDuration,
+                }}
+              />
             </div>
           ))}
         </div>

--- a/src/frontend/eyesee-admin/src/components/dashBoard/TestInfo.tsx
+++ b/src/frontend/eyesee-admin/src/components/dashBoard/TestInfo.tsx
@@ -1,0 +1,23 @@
+import React, { ReactNode } from "react";
+
+type TestInfoProps = {
+  examName: string;
+  examDuration: number;
+  children?: ReactNode;
+};
+
+const TestInfo = ({ examName, examDuration, children }: TestInfoProps) => {
+  return (
+    <>
+      <div>
+        <p className="text-[20px] font-bold">{examName}</p>
+        <p className="text-[18px] font-bold">🕐 {examDuration}분</p>
+      </div>
+      <div className="w-full flex justify-end items-center gap-5 mb-5">
+        {children}
+      </div>
+    </>
+  );
+};
+
+export default TestInfo;

--- a/src/frontend/eyesee-admin/src/components/dashBoard/UserSection.tsx
+++ b/src/frontend/eyesee-admin/src/components/dashBoard/UserSection.tsx
@@ -8,7 +8,7 @@ type UserSectionProps = {
 
 const UserSection = ({ sessionData }: UserSectionProps) => {
   return (
-    <div className="py-8 px-2.5">
+    <div className="w-[342px] py-8 px-2.5">
       <div className="text-[#999] text-[20px] font-bold mb-12">
         <span className="pl-3 pr-5">〈</span>
         {sessionData.examName}

--- a/src/frontend/eyesee-admin/src/components/dashBoard/UserSection.tsx
+++ b/src/frontend/eyesee-admin/src/components/dashBoard/UserSection.tsx
@@ -1,16 +1,27 @@
+"use client";
+
 import { testSesstion } from "@/types/user";
 import React from "react";
 import UserCard from "./UserCard";
+import { useRouter } from "next/navigation";
 
 type UserSectionProps = {
   sessionData: testSesstion;
 };
 
 const UserSection = ({ sessionData }: UserSectionProps) => {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push(`/mypage`);
+  };
+
   return (
     <div className="w-[342px] py-8 px-2.5">
       <div className="text-[#999] text-[20px] font-bold mb-12">
-        <span className="pl-3 pr-5">〈</span>
+        <span onClick={handleClick} className="pl-3 pr-5">
+          〈
+        </span>
         {sessionData.examName}
       </div>
       <div className="px-5">
@@ -19,7 +30,7 @@ const UserSection = ({ sessionData }: UserSectionProps) => {
         </div>
         <div className="bg-[rgba(9,38,102,0.10)] w-fit rounded-xl h-[80vh] overflow-scroll">
           {sessionData.user.map((user) => (
-            <UserCard user={user} />
+            <UserCard key={user.userId} user={user} />
           ))}
         </div>
       </div>

--- a/src/frontend/eyesee-admin/src/components/mypage/BeforeSection.tsx
+++ b/src/frontend/eyesee-admin/src/components/mypage/BeforeSection.tsx
@@ -4,14 +4,14 @@ import { testState } from "@/constant/test";
 
 const BeforeSection = () => {
   return (
-    <div className="bg-[rgba(14,29,60,0.20)] h-[64vh] px-4 rounded-lg">
+    <div className="bg-[rgba(14,29,60,0.20)] p-4 rounded-lg">
       <div className="flex items-center gap-2.5 p-2.5 pb-5">
         <span className="text-[#6f6f6f] text-lg font-normal">Before</span>
         <span className="text-[#6f6f6f] text-lg font-semibold">
           {beforeTestData.length}
         </span>
       </div>
-      <div className="flex flex-col items-center gap-4 h-[55vh] overflow-scroll scrollbar-hide">
+      <div className="flex flex-col items-center gap-4">
         {beforeTestData.map((test) => (
           <TestCard test={test} type={testState.BEFORE} />
         ))}

--- a/src/frontend/eyesee-admin/src/components/mypage/DoneSection.tsx
+++ b/src/frontend/eyesee-admin/src/components/mypage/DoneSection.tsx
@@ -4,14 +4,14 @@ import { testState } from "@/constant/test";
 
 const DoneSection = () => {
   return (
-    <div className="bg-[rgba(14,29,60,0.20)] h-[64vh] px-4 rounded-lg">
+    <div className="bg-[rgba(14,29,60,0.20)] p-4 rounded-lg">
       <div className="flex items-center gap-2.5 p-2.5 pb-5">
         <span className="text-[#6f6f6f] text-lg font-normal">Done</span>
         <span className="text-[#6f6f6f] text-lg font-semibold">
           {beforeTestData.length}
         </span>
       </div>
-      <div className="flex flex-col items-center gap-4 h-[55vh] overflow-scroll scrollbar-hide">
+      <div className="flex flex-col items-center gap-4">
         {beforeTestData.map((test) => (
           <TestCard test={test} type={testState.DONE} />
         ))}

--- a/src/frontend/eyesee-admin/src/components/mypage/InProgressSection.tsx
+++ b/src/frontend/eyesee-admin/src/components/mypage/InProgressSection.tsx
@@ -4,14 +4,14 @@ import { testState } from "@/constant/test";
 
 const InProgressSection = () => {
   return (
-    <div className="bg-[rgba(14,29,60,0.20)] h-[64vh] px-4 rounded-lg">
+    <div className="bg-[rgba(14,29,60,0.20)] p-4 rounded-lg">
       <div className="flex items-center gap-2.5 p-2.5 pb-5">
         <span className="text-[#6f6f6f] text-lg font-normal">In Progress</span>
         <span className="text-[#6f6f6f] text-lg font-semibold">
           {beforeTestData.length}
         </span>
       </div>
-      <div className="flex flex-col items-center gap-4 h-[55vh] overflow-scroll scrollbar-hide">
+      <div className="flex flex-col items-center gap-4">
         {beforeTestData.map((test) => (
           <TestCard test={test} type={testState.INPROGRESS} />
         ))}

--- a/src/frontend/eyesee-admin/src/components/userDetail/CheatingVideo.tsx
+++ b/src/frontend/eyesee-admin/src/components/userDetail/CheatingVideo.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { cheatingVideo } from "@/types/timeLine";
+
+type CheatingVideoProps = {
+  cheatingVideo: cheatingVideo;
+  cheatingType: string;
+  cheatingCounts: number;
+};
+
+const CheatingVideo = ({
+  cheatingVideo,
+  cheatingType,
+  cheatingCounts,
+}: CheatingVideoProps) => {
+  return (
+    <div className="text-white">
+      <div className="bg-[rgba(58,64,97,0.7)] text-xl px-6 py-4 rounded-t-lg flex justify-between items-center">
+        ⏳ {cheatingVideo.startTime} ~ {cheatingVideo.endTime}
+        <button className="bg-[#EF4444] px-3 py-2 flex justify-center items-center rounded-lg text-base">
+          {cheatingType} {cheatingCounts}회
+        </button>
+      </div>
+      <video
+        src={cheatingVideo.filepath}
+        controls
+        className="w-full h-auto rounded-b-lg"
+      ></video>
+    </div>
+  );
+};
+
+export default CheatingVideo;

--- a/src/frontend/eyesee-admin/src/components/userDetail/CheatingVideo.tsx
+++ b/src/frontend/eyesee-admin/src/components/userDetail/CheatingVideo.tsx
@@ -23,7 +23,7 @@ const CheatingVideo = ({
       <video
         src={cheatingVideo.filepath}
         controls
-        className="w-full h-auto rounded-b-lg"
+        className="w-full max-h-[62vh] rounded-b-lg"
       ></video>
     </div>
   );

--- a/src/frontend/eyesee-admin/src/components/userDetail/TimeLine.tsx
+++ b/src/frontend/eyesee-admin/src/components/userDetail/TimeLine.tsx
@@ -1,12 +1,14 @@
 import CircleIcon from "@/assets/icons/Circle.svg";
 import { timeLineType } from "@/types/timeLine";
 import { useParams, useRouter } from "next/navigation";
+import { Dispatch, SetStateAction } from "react";
 
 type TimeLineProps = {
   timeLineData: timeLineType;
+  setVideoNum: Dispatch<SetStateAction<number>>;
 };
 
-const TimeLine = ({ timeLineData }: TimeLineProps) => {
+const TimeLine = ({ timeLineData, setVideoNum }: TimeLineProps) => {
   const router = useRouter();
   const { examId } = useParams();
 
@@ -15,7 +17,7 @@ const TimeLine = ({ timeLineData }: TimeLineProps) => {
   };
 
   return (
-    <div className="py-8 px-2.5 w-[342px]">
+    <div className="py-8 px-2.5 w-[342px] bg-white">
       <div className="text-[#0E1D3C] text-[20px] font-bold mb-12">
         <span onClick={handleClick} className="pl-3 pr-5">
           〈
@@ -26,7 +28,8 @@ const TimeLine = ({ timeLineData }: TimeLineProps) => {
         {timeLineData.cheatingStatistics.map((cheating, index) => (
           <div
             key={cheating.cheatingStatisticsId}
-            className="absolute left-0 flex items-center gap-10"
+            onClick={() => setVideoNum(index)}
+            className="absolute left-0 flex items-center gap-10 cursor-pointer"
             style={{ left: -9, top: `${index * 30}%` }}
           >
             <CircleIcon />

--- a/src/frontend/eyesee-admin/src/components/userDetail/TimeLine.tsx
+++ b/src/frontend/eyesee-admin/src/components/userDetail/TimeLine.tsx
@@ -1,0 +1,46 @@
+import CircleIcon from "@/assets/icons/Circle.svg";
+import { timeLineType } from "@/types/timeLine";
+import { useParams, useRouter } from "next/navigation";
+
+type TimeLineProps = {
+  timeLineData: timeLineType;
+};
+
+const TimeLine = ({ timeLineData }: TimeLineProps) => {
+  const router = useRouter();
+  const { examId } = useParams();
+
+  const handleClick = () => {
+    router.push(`/dashboard/${examId}`);
+  };
+
+  return (
+    <div className="py-8 px-2.5 w-[342px]">
+      <div className="text-[#0E1D3C] text-[20px] font-bold mb-12">
+        <span onClick={handleClick} className="pl-3 pr-5">
+          〈
+        </span>
+        {timeLineData.userName}님 Time Line
+      </div>
+      <div className="relative border-l-2 border-l-[#0E1D3C] h-[80vh] ml-12">
+        {timeLineData.cheatingStatistics.map((cheating, index) => (
+          <div
+            key={cheating.cheatingStatisticsId}
+            className="absolute left-0 flex items-center gap-10"
+            style={{ left: -9, top: `${index * 30}%` }}
+          >
+            <CircleIcon />
+            <div className="text-xl text-[#000]">
+              <div>{cheating.DetectedTime.slice(-8)}</div>
+              <div>
+                {cheating.cheatingType} {cheating.cheatingCount}회 감지
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TimeLine;

--- a/src/frontend/eyesee-admin/src/types/timeLine.ts
+++ b/src/frontend/eyesee-admin/src/types/timeLine.ts
@@ -51,19 +51,22 @@ export const dummyTimeLineData: timeLineType = {
       videoId: 1,
       startTime: "2023-11-02T10:20:00",
       endTime: "2023-11-02T10:22:00",
-      filepath: "/videos/cheating_1.mp4",
+      filepath:
+        "https://videos.pexels.com/video-files/4769538/4769538-uhd_2732_1440_25fps.mp4",
     },
     {
       videoId: 2,
       startTime: "2023-11-02T10:25:00",
       endTime: "2023-11-02T10:27:00",
-      filepath: "/videos/cheating_2.mp4",
+      filepath:
+        "https://videos.pexels.com/video-files/8196796/8196796-hd_1920_1080_25fps.mp4",
     },
     {
       videoId: 3,
       startTime: "2023-11-02T10:30:00",
       endTime: "2023-11-02T10:31:00",
-      filepath: "/videos/cheating_3.mp4",
+      filepath:
+        "https://videos.pexels.com/video-files/4778714/4778714-uhd_2732_1440_25fps.mp4",
     },
   ],
 };

--- a/src/frontend/eyesee-admin/src/types/timeLine.ts
+++ b/src/frontend/eyesee-admin/src/types/timeLine.ts
@@ -1,0 +1,69 @@
+export type cheatingStatistics = {
+  cheatingStatisticsId: number;
+  cheatingType: string;
+  cheatingCount: number;
+  DetectedTime: string;
+};
+
+export type cheatingVideo = {
+  videoId: number;
+  startTime: string;
+  endTime: string;
+  filepath: string;
+};
+
+export type timeLineType = {
+  userId: number;
+  userName: string;
+  userNum: number;
+  seatNum: number;
+  cheatingStatistics: cheatingStatistics[];
+  cheatingVideos: cheatingVideo[];
+};
+
+export const dummyTimeLineData: timeLineType = {
+  userId: 1,
+  userName: "김호정",
+  userNum: 2022111111,
+  seatNum: 23,
+  cheatingStatistics: [
+    {
+      cheatingStatisticsId: 1,
+      cheatingType: "휴대폰 사용",
+      cheatingCount: 2,
+      DetectedTime: "2023-11-02T10:20:00",
+    },
+    {
+      cheatingStatisticsId: 2,
+      cheatingType: "시선 이탈",
+      cheatingCount: 5,
+      DetectedTime: "2023-11-02T10:25:00",
+    },
+    {
+      cheatingStatisticsId: 3,
+      cheatingType: "종이 사용",
+      cheatingCount: 1,
+      DetectedTime: "2023-11-02T10:30:00",
+    },
+  ],
+  cheatingVideos: [
+    {
+      videoId: 1,
+      startTime: "2023-11-02T10:20:00",
+      endTime: "2023-11-02T10:22:00",
+      filepath: "/videos/cheating_1.mp4",
+    },
+    {
+      videoId: 2,
+      startTime: "2023-11-02T10:25:00",
+      endTime: "2023-11-02T10:27:00",
+      filepath: "/videos/cheating_2.mp4",
+    },
+    {
+      videoId: 3,
+      startTime: "2023-11-02T10:30:00",
+      endTime: "2023-11-02T10:31:00",
+      filepath: "/videos/cheating_3.mp4",
+    },
+  ],
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #19

## 📝 작업 내용

> 대시보드 수험자 상세보기 페이지를 구축하였습니다
> 추후, video 실제 데이터가 포함될 예정입니다.

#### 스크린샷 (선택)

![상세페이지](https://github.com/user-attachments/assets/8fde1110-7263-410c-8936-12fabe311b6f)

