### PR TITLE
BE: [fix] 시험 등록 api jwt 기반 인증 수정 #6

### DIFF
--- a/src/backend/Eyesee/build.gradle
+++ b/src/backend/Eyesee/build.gradle
@@ -30,10 +30,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // 랜덤 코드 생성
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
+
     // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'  // JSON 파싱을 위해 jackson을 사용
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/backend/Eyesee/src/main/java/com/fortune/eyesee/controller/ExamController.java
+++ b/src/backend/Eyesee/src/main/java/com/fortune/eyesee/controller/ExamController.java
@@ -3,19 +3,20 @@ package com.fortune.eyesee.controller;
 import com.fortune.eyesee.common.exception.BaseException;
 import com.fortune.eyesee.common.response.BaseResponse;
 import com.fortune.eyesee.common.response.BaseResponseCode;
-import com.fortune.eyesee.dto.ExamCodeRequestDTO;
-import com.fortune.eyesee.dto.ExamResponseDTO;
-import com.fortune.eyesee.dto.UserDetailResponseDTO;
-import com.fortune.eyesee.dto.UserListResponseDTO;
+import com.fortune.eyesee.dto.*;
 import com.fortune.eyesee.enums.ExamStatus;
 import com.fortune.eyesee.service.ExamService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.servlet.http.HttpSession;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/exams")
@@ -86,6 +87,21 @@ public class ExamController {
         // adminId를 사용하지 않는 조회 방식으로 수정
         List<ExamResponseDTO> examList = examService.getExamsByStatus(null, examStatus);
         return ResponseEntity.ok(new BaseResponse<>(examList));
+    }
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<Map<String, String>>> registerExam(@RequestBody ExamRequestDTO examRequestDTO ) {
+
+        // SecurityContextHolder에서 adminId를 가져옴
+        Integer adminId = (Integer) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        ExamResponseDTO examResponseDTO = examService.registerExam(adminId, examRequestDTO);
+
+        // examRandomCode만 포함된 응답 생성
+        Map<String, String> response = new HashMap<>();
+        response.put("examRandomCode", examResponseDTO.getExamRandomCode());
+
+        return ResponseEntity.ok(new BaseResponse<>(response, "시험 등록에 성공했습니다."));
     }
 
     // 특정 시험 ID에 해당하는 세션 내 모든 학생들의 리스트를 조회

--- a/src/backend/Eyesee/src/main/java/com/fortune/eyesee/dto/ExamRequestDTO.java
+++ b/src/backend/Eyesee/src/main/java/com/fortune/eyesee/dto/ExamRequestDTO.java
@@ -1,0 +1,20 @@
+package com.fortune.eyesee.dto;
+
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Data
+public class ExamRequestDTO {
+    private String examName;
+    private String examSemester;
+    private Integer examStudentNumber;
+    private String examLocation;
+    private LocalDate examDate;
+    private LocalTime examStartTime;
+    private Integer examDuration;
+    private Integer examQuestionNumber;
+    private Integer examTotalScore;
+    private String examNotice;
+}

--- a/src/backend/Eyesee/src/main/java/com/fortune/eyesee/service/ExamService.java
+++ b/src/backend/Eyesee/src/main/java/com/fortune/eyesee/service/ExamService.java
@@ -2,12 +2,14 @@ package com.fortune.eyesee.service;
 
 import com.fortune.eyesee.common.exception.BaseException;
 import com.fortune.eyesee.common.response.BaseResponseCode;
+import com.fortune.eyesee.dto.ExamRequestDTO;
 import com.fortune.eyesee.dto.ExamResponseDTO;
 import com.fortune.eyesee.dto.UserDetailResponseDTO;
 import com.fortune.eyesee.dto.UserListResponseDTO;
 import com.fortune.eyesee.entity.*;
 import com.fortune.eyesee.enums.ExamStatus;
 import com.fortune.eyesee.repository.*;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -26,6 +28,7 @@ public class ExamService {
     private final VideoRecordingRepository videoRecordingRepository;
     private final DetectedCheatingRepository detectedCheatingRepository;
     private final CheatingTypeRepository cheatingTypeRepository;
+    private final AdminRepository adminRepository;
 
     @Autowired
     public ExamService(ExamRepository examRepository,
@@ -34,7 +37,8 @@ public class ExamService {
                        CheatingStatisticsRepository cheatingStatisticsRepository,
                        VideoRecordingRepository videoRecordingRepository,
                        DetectedCheatingRepository detectedCheatingRepository,
-                       CheatingTypeRepository cheatingTypeRepository) {
+                       CheatingTypeRepository cheatingTypeRepository,
+                       AdminRepository adminRepository) {
         this.examRepository = examRepository;
         this.userRepository = userRepository;
         this.sessionRepository = sessionRepository;
@@ -42,6 +46,57 @@ public class ExamService {
         this.videoRecordingRepository = videoRecordingRepository;
         this.detectedCheatingRepository = detectedCheatingRepository;
         this.cheatingTypeRepository = cheatingTypeRepository;
+        this.adminRepository = adminRepository;
+    }
+
+    // 시험 등록 메서드
+    public ExamResponseDTO registerExam(Integer adminId, ExamRequestDTO examRequestDTO) {
+        // Admin 인증 확인
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(() -> new BaseException(BaseResponseCode.UNAUTHORIZED));
+
+        // 10자리 랜덤 영숫자 코드 생성
+        String examRandomCode = RandomStringUtils.randomAlphanumeric(10);
+
+        // Exam 생성
+        Exam exam = new Exam();
+        exam.setAdmin(admin);
+        exam.setExamName(examRequestDTO.getExamName());
+        exam.setExamSemester(examRequestDTO.getExamSemester());
+        exam.setExamStudentNumber(examRequestDTO.getExamStudentNumber());
+        exam.setExamLocation(examRequestDTO.getExamLocation());
+        exam.setExamDate(examRequestDTO.getExamDate());
+        exam.setExamStartTime(examRequestDTO.getExamStartTime());
+        exam.setExamDuration(examRequestDTO.getExamDuration());
+        exam.setExamQuestionNumber(examRequestDTO.getExamQuestionNumber());
+        exam.setExamTotalScore(examRequestDTO.getExamTotalScore());
+        exam.setExamNotice(examRequestDTO.getExamNotice());
+        exam.setExamStatus(ExamStatus.BEFORE);
+        exam.setExamRandomCode(examRandomCode);
+
+        // Exam 저장 후 ID 생성
+        examRepository.save(exam);
+
+        // ExamId를 사용해 Session 생성 및 설정
+        Session session = new Session();
+        session.setSessionId(exam.getExamId()); // ExamId와 동일하게 설정
+        session.setExam(exam);
+        sessionRepository.save(session);
+
+        return new ExamResponseDTO(
+                exam.getExamId(),
+                exam.getExamName(),
+                exam.getExamSemester(),
+                exam.getExamStudentNumber(),
+                exam.getExamLocation(),
+                exam.getExamDate(),
+                exam.getExamStartTime(),
+                exam.getExamDuration(),
+                exam.getExamStatus(),
+                exam.getExamNotice(),
+                session.getSessionId(),
+                exam.getExamRandomCode()
+        );
     }
 
     // 특정 시험 ID로 존재 여부 확인


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #6, #27 

## 📝 작업 내용

> 시험 등록 api main 브랜치에 옮기면서 Jwt 적용했습니다.

#### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
